### PR TITLE
Gstreamer - add object set to API.

### DIFF
--- a/pkg/gst/gst.c
+++ b/pkg/gst/gst.c
@@ -47,7 +47,7 @@ static gboolean gstreamer_bus_call(GstBus *bus, GstMessage *msg, gpointer user_d
       gstreamer_pipeline_log(ctx, "debug",
         "got tags from element %s",
           GST_OBJECT_NAME(msg->src));
-  
+
       gst_tag_list_unref(tags);
       break;
     }
@@ -162,4 +162,51 @@ void gstreamer_pipeline_push(GstPipelineCtx *ctx, void *buffer, int bufferLen) {
     GstBuffer *buffer = gst_buffer_new_wrapped(p, bufferLen);
     gst_app_src_push_buffer(GST_APP_SRC(ctx->appsrc), buffer);
   }
+}
+
+gboolean gstreamer_pipeline_set_prop_int(GstPipelineCtx *ctx, char *binName, char *prop, gint value) {
+  GstElement *el = gst_bin_get_by_name(GST_BIN(ctx->pipeline), binName);
+  if (el == NULL) return FALSE;
+
+  g_object_set(G_OBJECT(el),
+    prop, value,
+    NULL);
+
+  gst_object_unref(el);
+  return TRUE;
+}
+
+gboolean gstreamer_pipeline_set_caps_framerate(GstPipelineCtx *ctx, const gchar* binName, gint numerator, gint denominator) {
+  GstElement *el = gst_bin_get_by_name(GST_BIN(ctx->pipeline), binName);
+  if (el == NULL) return FALSE;
+
+  GstCaps *caps = gst_caps_new_simple("video/x-raw",
+    "framerate", GST_TYPE_FRACTION, numerator, denominator,
+    NULL);
+
+  g_object_set(G_OBJECT(el),
+    "caps", caps,
+    NULL);
+
+  gst_caps_unref(caps);
+  gst_object_unref(el);
+  return TRUE;
+}
+
+gboolean gstreamer_pipeline_set_caps_resolution(GstPipelineCtx *ctx, const gchar* binName, gint width, gint height) {
+  GstElement *el = gst_bin_get_by_name(GST_BIN(ctx->pipeline), binName);
+  if (el == NULL) return FALSE;
+
+  GstCaps *caps = gst_caps_new_simple("video/x-raw",
+    "width", G_TYPE_INT, width,
+    "height", G_TYPE_INT, height,
+    NULL);
+
+  g_object_set(G_OBJECT(el),
+    "caps", caps,
+    NULL);
+
+  gst_caps_unref(caps);
+  gst_object_unref(el);
+  return TRUE;
 }

--- a/pkg/gst/gst.h
+++ b/pkg/gst/gst.h
@@ -22,5 +22,9 @@ void gstreamer_pipeline_pause(GstPipelineCtx *ctx);
 void gstreamer_pipeline_destory(GstPipelineCtx *ctx);
 void gstreamer_pipeline_push(GstPipelineCtx *ctx, void *buffer, int bufferLen);
 
+gboolean gstreamer_pipeline_set_prop_int(GstPipelineCtx *ctx, char *binName, char *prop, gint value);
+gboolean gstreamer_pipeline_set_caps_framerate(GstPipelineCtx *ctx, const gchar* binName, gint numerator, gint denominator);
+gboolean gstreamer_pipeline_set_caps_resolution(GstPipelineCtx *ctx, const gchar* binName, gint width, gint height);
+
 void gstreamer_init(void);
 void gstreamer_loop(void);

--- a/pkg/types/capture.go
+++ b/pkg/types/capture.go
@@ -104,7 +104,7 @@ func (config *VideoConfig) GetPipeline(screen ScreenSize) (string, error) {
 			return "", err
 		}
 
-		fpsPipeline = fmt.Sprintf("! video/x-raw,framerate=%d/100 ! videoconvert ! queue", int(val*100))
+		fpsPipeline = fmt.Sprintf("! capsfilter caps=video/x-raw,framerate=%d/100 name=framerate ! videoconvert ! queue", int(val*100))
 	}
 
 	// get scale pipeline
@@ -130,11 +130,11 @@ func (config *VideoConfig) GetPipeline(screen ScreenSize) (string, error) {
 			return "", err
 		}
 
-		scalePipeline = fmt.Sprintf("! videoscale ! video/x-raw,width=%d,height=%d ! queue", w, h)
+		scalePipeline = fmt.Sprintf("! videoscale ! capsfilter caps=video/x-raw,width=%d,height=%d name=resolution ! queue", w, h)
 	}
 
 	// get encoder pipeline
-	encPipeline := fmt.Sprintf("! %s", config.GstEncoder)
+	encPipeline := fmt.Sprintf("! %s name=encoder", config.GstEncoder)
 	for key, expr := range config.GstParams {
 		if expr == "" {
 			continue


### PR DESCRIPTION
Adding object set to gstreamer API:
- set integer (encoding bitrate)
- set caps framerate
- set caps resolution