### PR TITLE
Fix drop upload

### DIFF
--- a/internal/desktop/drop.go
+++ b/internal/desktop/drop.go
@@ -43,7 +43,12 @@ func (manager *DesktopManagerCtx) DropFiles(x int, y int, files []string) bool {
 
 	finished := make(chan bool)
 	drop.Emmiter.Once("finish", func(payload ...any) {
-		finished <- payload[0].(bool)
+		b, ok := payload[0].(bool)
+		// workaround until https://github.com/kataras/go-events/pull/8 is merged
+		if !ok {
+			b = (payload[0].([]any))[0].(bool)
+		}
+		finished <- b
 	})
 
 	manager.ResetKeys()

--- a/pkg/drop/drop.c
+++ b/pkg/drop/drop.c
@@ -39,7 +39,7 @@ void dragWindowOpen(char **uris) {
 
   gtk_init(NULL, NULL);
 
-  GtkWidget *widget = gtk_window_new(GTK_WINDOW_TOPLEVEL);;
+  GtkWidget *widget = gtk_window_new(GTK_WINDOW_POPUP);
   GtkWindow *window = GTK_WINDOW(widget);
 
   gtk_window_move(window, 0, 0);

--- a/pkg/gst/gst.c
+++ b/pkg/gst/gst.c
@@ -1,15 +1,5 @@
 #include "gst.h"
 
-void gstreamer_init(void) {
-  gst_init(NULL, NULL);
-}
-
-GMainLoop *gstreamer_main_loop = NULL;
-void gstreamer_loop(void) {
-  gstreamer_main_loop = g_main_loop_new (NULL, FALSE);
-  g_main_loop_run(gstreamer_main_loop);
-}
-
 static void gstreamer_pipeline_log(GstPipelineCtx *ctx, char* level, const char* format, ...) {
   va_list argptr;
   va_start(argptr, format);

--- a/pkg/gst/gst.go
+++ b/pkg/gst/gst.go
@@ -33,9 +33,7 @@ var pipelinesLock sync.Mutex
 var registry *C.GstRegistry
 
 func init() {
-	C.gstreamer_init()
-	go C.gstreamer_loop()
-
+	C.gst_init(nil, nil)
 	registry = C.gst_registry_get()
 }
 

--- a/pkg/gst/gst.h
+++ b/pkg/gst/gst.h
@@ -25,6 +25,3 @@ void gstreamer_pipeline_push(GstPipelineCtx *ctx, void *buffer, int bufferLen);
 gboolean gstreamer_pipeline_set_prop_int(GstPipelineCtx *ctx, char *binName, char *prop, gint value);
 gboolean gstreamer_pipeline_set_caps_framerate(GstPipelineCtx *ctx, const gchar* binName, gint numerator, gint denominator);
 gboolean gstreamer_pipeline_set_caps_resolution(GstPipelineCtx *ctx, const gchar* binName, gint width, gint height);
-
-void gstreamer_init(void);
-void gstreamer_loop(void);


### PR DESCRIPTION
Since v1.5.2 drop upload did not work.

```
(neko:793): Gtk-CRITICAL **: 19:15:55.437: gtk_widget_destroy: assertion 'GTK_IS_WIDGET (widget)' failed
```

```
[xcb] Unknown request in queue while dequeuing
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
```

```
[xcb] Unknown sequence number while processing reply
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
neko: ../../src/xcb_io.c:725: _XReply: Assertion `!xcb_xlib_threads_sequence_lost' failed.
```

* Adding gst main loop seems to have created deadlock in `gtk_init` function.
* `kataras/go-events@v0.0.3` version contains bug, so `finished` handler for `Once` event listener got bad type assertion and could cause panic.

Upload test:

```bash
curl -H "Authorization: Bearer neko123" -F x=10 -F y=20 -F files=@/root/test http://127.0.0.1:3000/api/room/upload/drop
```