### PR TITLE
Fix duplicate stream request

### DIFF
--- a/internal/webrtc/track.go
+++ b/internal/webrtc/track.go
@@ -100,6 +100,11 @@ func (t *Track) SetStream(stream types.StreamSinkManager) error {
 	t.streamMu.Lock()
 	defer t.streamMu.Unlock()
 
+	// if we already listen to the stream, do nothing
+	if t.stream == stream {
+		return nil
+	}
+
 	var err error
 	if t.stream != nil {
 		err = t.stream.MoveListenerTo(&t.listener, stream)


### PR DESCRIPTION
We do not need to (and should not) move user from - to the same stream beacuse it is 1) pointless and 2) creates deadlock.