### PR TITLE
Add batch endpoint

### DIFF
--- a/internal/http/batch.go
+++ b/internal/http/batch.go
@@ -24,17 +24,10 @@ type BatchResponse struct {
 	Status int             `json:"status"`
 }
 
-func (b *BatchResponse) Error(httpErr *utils.HTTPError) error {
+func (b *BatchResponse) Error(httpErr *utils.HTTPError) (err error) {
+	b.Body, err = json.Marshal(httpErr)
 	b.Status = httpErr.Code
-	httpErr.Code = 0
-
-	data, err := json.Marshal(httpErr)
-	if err != nil {
-		return err
-	}
-
-	b.Body = data
-	return nil
+	return
 }
 
 type batchHandler struct {

--- a/internal/http/batch.go
+++ b/internal/http/batch.go
@@ -37,13 +37,11 @@ type batchHandler struct {
 }
 
 func (b *batchHandler) Handle(w http.ResponseWriter, r *http.Request) error {
-	// parse BatchRequests
 	var requests []BatchRequest
 	if err := json.NewDecoder(r.Body).Decode(&requests); err != nil {
 		return err
 	}
 
-	// execute BatchRequests
 	responses := make([]BatchResponse, len(requests))
 	for i, request := range requests {
 		res := BatchResponse{
@@ -63,7 +61,7 @@ func (b *batchHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 			continue
 		}
 
-		// do request
+		// prepare request
 		req, err := http.NewRequest(request.Method, request.Path, bytes.NewBuffer(request.Body))
 		if err != nil {
 			return err
@@ -95,9 +93,7 @@ func (b *batchHandler) Handle(w http.ResponseWriter, r *http.Request) error {
 		}
 	}
 
-	// write BatchResponses
-	w.Header().Set("Content-Type", "application/json")
-	return json.NewEncoder(w).Encode(responses)
+	return utils.HttpSuccess(w, responses)
 }
 
 type responseRecorder struct {

--- a/internal/http/batch.go
+++ b/internal/http/batch.go
@@ -14,13 +14,13 @@ import (
 type BatchRequest struct {
 	Path   string          `json:"path"`
 	Method string          `json:"method"`
-	Body   json.RawMessage `json:"body"`
+	Body   json.RawMessage `json:"body,omitempty"`
 }
 
 type BatchResponse struct {
 	Path   string          `json:"path"`
 	Method string          `json:"method"`
-	Body   json.RawMessage `json:"body"`
+	Body   json.RawMessage `json:"body,omitempty"`
 	Status int             `json:"status"`
 }
 

--- a/internal/http/batch.go
+++ b/internal/http/batch.go
@@ -1,0 +1,134 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/demodesk/neko/pkg/types"
+	"github.com/demodesk/neko/pkg/utils"
+)
+
+type BatchRequest struct {
+	Path   string          `json:"path"`
+	Method string          `json:"method"`
+	Body   json.RawMessage `json:"body"`
+}
+
+type BatchResponse struct {
+	Path   string          `json:"path"`
+	Method string          `json:"method"`
+	Body   json.RawMessage `json:"body"`
+	Status int             `json:"status"`
+}
+
+func (b *BatchResponse) Error(httpErr *utils.HTTPError) error {
+	b.Status = httpErr.Code
+	httpErr.Code = 0
+
+	data, err := json.Marshal(httpErr)
+	if err != nil {
+		return err
+	}
+
+	b.Body = data
+	return nil
+}
+
+type batchHandler struct {
+	Router     types.Router
+	PathPrefix string
+	Excluded   []string
+}
+
+func (b *batchHandler) Handle(w http.ResponseWriter, r *http.Request) error {
+	// parse BatchRequests
+	var requests []BatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&requests); err != nil {
+		return err
+	}
+
+	// execute BatchRequests
+	responses := make([]BatchResponse, len(requests))
+	for i, request := range requests {
+		res := BatchResponse{
+			Path:   request.Path,
+			Method: request.Method,
+		}
+
+		if !strings.HasPrefix(request.Path, b.PathPrefix) {
+			res.Error(utils.HttpBadRequest("this path is not allowed in batch requests"))
+			responses[i] = res
+			continue
+		}
+
+		if exists, _ := utils.ArrayIn(request.Path, b.Excluded); exists {
+			res.Error(utils.HttpBadRequest("this path is excluded from batch requests"))
+			responses[i] = res
+			continue
+		}
+
+		// do request
+		req, err := http.NewRequest(request.Method, request.Path, bytes.NewBuffer(request.Body))
+		if err != nil {
+			return err
+		}
+
+		// copy headers
+		for k, vv := range r.Header {
+			for _, v := range vv {
+				req.Header.Add(k, v)
+			}
+		}
+
+		// execute request
+		rr := newResponseRecorder()
+		b.Router.ServeHTTP(rr, req)
+
+		// read response
+		body, err := io.ReadAll(rr.Body)
+		if err != nil {
+			return err
+		}
+
+		// write response
+		responses[i] = BatchResponse{
+			Path:   request.Path,
+			Method: request.Method,
+			Body:   body,
+			Status: rr.Code,
+		}
+	}
+
+	// write BatchResponses
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(responses)
+}
+
+type responseRecorder struct {
+	Code      int
+	HeaderMap http.Header
+	Body      *bytes.Buffer
+}
+
+func newResponseRecorder() *responseRecorder {
+	return &responseRecorder{
+		Code:      http.StatusOK,
+		HeaderMap: make(http.Header),
+		Body:      new(bytes.Buffer),
+	}
+}
+
+func (w *responseRecorder) Header() http.Header {
+	return w.HeaderMap
+}
+
+func (w *responseRecorder) Write(b []byte) (int, error) {
+	return w.Body.Write(b)
+}
+
+func (w *responseRecorder) WriteHeader(code int) {
+	w.Code = code
+}

--- a/internal/http/manager.go
+++ b/internal/http/manager.go
@@ -42,6 +42,16 @@ func New(WebSocketManager types.WebSocketManager, ApiManager types.ApiManager, c
 		return config.AllowOrigin(r.Header.Get("Origin"))
 	}))
 
+	batch := batchHandler{
+		Router:     router,
+		PathPrefix: "/api",
+		Excluded: []string{
+			"/api/batch", // do not allow batchception
+			"/api/ws",
+		},
+	}
+	router.Post("/api/batch", batch.Handle)
+
 	router.Get("/health", func(w http.ResponseWriter, r *http.Request) error {
 		_, err := w.Write([]byte("true"))
 		return err

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -38,6 +38,28 @@ paths:
         '200':
           description: OK
 
+  /api/batch:
+    post:
+      summary: batch
+      operationId: batch
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BatchResponse'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/BatchRequest'
+        required: true
+
   #
   # session
   #
@@ -929,6 +951,36 @@ components:
       properties:
         message:
           type: string
+
+    BatchRequest:
+      type: object
+      properties:
+        path:
+          type: string
+        method:
+          type: string
+          enum:
+            - GET
+            - POST
+            - DELETE
+        body:
+          description: Request body
+
+    BatchResponse:
+      type: object
+      properties:
+        path:
+          type: string
+        method:
+          type: string
+          enum:
+            - GET
+            - POST
+            - DELETE
+        body:
+          description: Response body
+        status:
+          type: integer
 
     #
     # session


### PR DESCRIPTION
Add a single endpoint `/api/batch` that can accept array of multiple requests and executes them.

```bash
curl -X POST http://127.0.0.1:3000/api/batch --data '[{"path":"/api/whoami", "method":"GET"},{"path":"/api/batch", "method":"GET"},{"path":"/api/whoami", "method":"GET"}]' | jq
```