### PR TITLE
Fix free keycodes maping

### DIFF
--- a/pkg/xorg/xorg.c
+++ b/pkg/xorg/xorg.c
@@ -191,10 +191,23 @@ void XFreeKeycodesInit(Display* dpy) {
     last = entry;
   }
 
-  if (last != NULL) {
-    // make as circular list
-    last->next = xFreeKeycodesHead;
+  // no free keycodes, pick last two keycodes anyway
+  if (last == NULL) {
+    xkeycode_t *entry1 = (xkeycode_t *) malloc(sizeof(xkeycode_t));
+    if (entry1 == NULL) return;
+    entry1->keycode = max-1;
+
+    xkeycode_t *entry2 = (xkeycode_t *) malloc(sizeof(xkeycode_t));
+    if (entry2 == NULL) return;
+    entry2->keycode = max-2;
+
+    xFreeKeycodesHead = entry1;
+    entry1->next = entry2;
+    last = entry2;
   }
+
+  // make as circular list
+  last->next = xFreeKeycodesHead;
 
   XFree(keysyms);
 }

--- a/pkg/xorg/xorg.h
+++ b/pkg/xorg/xorg.h
@@ -26,6 +26,11 @@ typedef struct xkeyentry_t {
   struct xkeyentry_t *next;
 } xkeyentry_t;
 
+typedef struct xkeycode_t {
+  KeyCode keycode;
+  struct xkeycode_t *next;
+} xkeycode_t;
+
 static void XKeyEntryAdd(KeySym keysym, KeyCode keycode);
 static KeyCode XKeyEntryGet(KeySym keysym);
 static KeyCode XkbKeysymToKeycode(Display *dpy, KeySym keysym);

--- a/pkg/xorg/xorg.h
+++ b/pkg/xorg/xorg.h
@@ -26,11 +26,6 @@ typedef struct xkeyentry_t {
   struct xkeyentry_t *next;
 } xkeyentry_t;
 
-typedef struct xkeycode_t {
-  KeyCode keycode;
-  struct xkeycode_t *next;
-} xkeycode_t;
-
 static void XKeyEntryAdd(KeySym keysym, KeyCode keycode);
 static KeyCode XKeyEntryGet(KeySym keysym);
 static KeyCode XkbKeysymToKeycode(Display *dpy, KeySym keysym);


### PR DESCRIPTION
Currently non-existing keys were mapped to a single keycode, usually `200`. This posed a problem if multiple keysyms have been pressed simultaneously, since they all shared a single keycode.

<del>New approach tries to get all free keycodes, puts them to a circular list. Each time when a new keycode is needed, the next free keycode is taken. Once they all get used, it repeats.<*del>

<del>If there is no free keycode available, we use last two anyway. It might be assigned for something different, but we reassign when needed.</del>

Worked in most cases but it did not respect modifiers, therefore code has been changed to Xkb implementation from TigerVNC. Known limitation is, that when all keycodes are used, they do not work anymore.

Memory leak from `XGetKeyboardMapping` function, its returned value has never been freed.