### PR TITLE
WebRTC ping over data channel

### DIFF
--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -475,7 +475,7 @@ func (manager *WebRTCManagerCtx) CreatePeer(session types.Session, bitrate int) 
 	})
 
 	dataChannel.OnMessage(func(message webrtc.DataChannelMessage) {
-		if err := manager.handle(message.Data, session); err != nil {
+		if err := manager.handle(message.Data, dataChannel, session); err != nil {
 			logger.Err(err).Msg("data handle failed")
 		}
 	})

--- a/internal/webrtc/payload/receive.go
+++ b/internal/webrtc/payload/receive.go
@@ -7,6 +7,7 @@ const (
 	OP_KEY_UP   = 0x04
 	OP_BTN_DOWN = 0x05
 	OP_BTN_UP   = 0x06
+	OP_PING     = 0x07
 )
 
 type Move struct {
@@ -27,4 +28,12 @@ type Key struct {
 	Header
 
 	Key uint32
+}
+
+type Ping struct {
+	Header
+
+	// client's timestamp split into two uint32
+	ClientTs1 uint32
+	ClientTs2 uint32
 }

--- a/internal/webrtc/payload/receive.go
+++ b/internal/webrtc/payload/receive.go
@@ -1,5 +1,7 @@
 package payload
 
+import "math"
+
 const (
 	OP_MOVE     = 0x01
 	OP_SCROLL   = 0x02
@@ -36,4 +38,8 @@ type Ping struct {
 	// client's timestamp split into two uint32
 	ClientTs1 uint32
 	ClientTs2 uint32
+}
+
+func (p Ping) ClientTs() uint64 {
+	return (uint64(p.ClientTs1) * uint64(math.MaxUint32)) + uint64(p.ClientTs2)
 }

--- a/internal/webrtc/payload/send.go
+++ b/internal/webrtc/payload/send.go
@@ -1,5 +1,7 @@
 package payload
 
+import "math"
+
 const (
 	OP_CURSOR_POSITION = 0x01
 	OP_CURSOR_IMAGE    = 0x02
@@ -28,4 +30,8 @@ type Pong struct {
 	// server's timestamp split into two uint32
 	ServerTs1 uint32
 	ServerTs2 uint32
+}
+
+func (p Pong) ServerTs() uint64 {
+	return (uint64(p.ServerTs1) * uint64(math.MaxUint32)) + uint64(p.ServerTs2)
 }

--- a/internal/webrtc/payload/send.go
+++ b/internal/webrtc/payload/send.go
@@ -3,6 +3,7 @@ package payload
 const (
 	OP_CURSOR_POSITION = 0x01
 	OP_CURSOR_IMAGE    = 0x02
+	OP_PONG            = 0x03
 )
 
 type CursorPosition struct {
@@ -19,4 +20,12 @@ type CursorImage struct {
 	Height uint16
 	Xhot   uint16
 	Yhot   uint16
+}
+
+type Pong struct {
+	Ping
+
+	// server's timestamp split into two uint32
+	ServerTs1 uint32
+	ServerTs2 uint32
 }


### PR DESCRIPTION
Implementing simple ping protocol, that only adds current timestamp to a message and sends it back. This allows client to calculate latency.