### PR TITLE
Gst: Emit video keyframe on demand.

### DIFF
--- a/pkg/gst/gst.c
+++ b/pkg/gst/gst.c
@@ -200,3 +200,15 @@ gboolean gstreamer_pipeline_set_caps_resolution(GstPipelineCtx *ctx, const gchar
   gst_object_unref(el);
   return TRUE;
 }
+
+gboolean gstreamer_pipeline_emit_video_keyframe(GstPipelineCtx *ctx) {
+	GstClock *clock = gst_pipeline_get_clock(GST_PIPELINE(ctx->pipeline));
+	gst_object_ref(clock);
+
+	GstClockTime time = gst_clock_get_time(clock);
+	GstClockTime now = time - gst_element_get_base_time(ctx->pipeline);
+	gst_object_unref(clock);
+
+	GstEvent *keyFrameEvent = gst_video_event_new_downstream_force_key_unit(now, time, now, TRUE, 0);
+	return gst_element_send_event(GST_ELEMENT(ctx->pipeline), keyFrameEvent);
+}

--- a/pkg/gst/gst.go
+++ b/pkg/gst/gst.go
@@ -1,7 +1,7 @@
 package gst
 
 /*
-#cgo pkg-config: gstreamer-1.0 gstreamer-app-1.0
+#cgo pkg-config: gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0
 
 #include "gst.h"
 */
@@ -46,6 +46,8 @@ type Pipeline interface {
 	SetPropInt(binName string, prop string, value int) bool
 	SetCapsFramerate(binName string, numerator, denominator int) bool
 	SetCapsResolution(binName string, width, height int) bool
+	// emit video keyframe
+	EmitVideoKeyframe() bool
 }
 
 type pipeline struct {
@@ -174,6 +176,11 @@ func (p *pipeline) SetCapsResolution(binName string, width, height int) bool {
 	p.logger.Debug().Msgf("setting caps resolution of %s to %dx%d", binName, width, height)
 
 	ok := C.gstreamer_pipeline_set_caps_resolution(p.ctx, cBinName, cWidth, cHeight)
+	return ok == C.TRUE
+}
+
+func (p *pipeline) EmitVideoKeyframe() bool {
+	ok := C.gstreamer_pipeline_emit_video_keyframe(p.ctx)
 	return ok == C.TRUE
 }
 

--- a/pkg/gst/gst.h
+++ b/pkg/gst/gst.h
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <gst/gst.h>
 #include <gst/app/gstappsrc.h>
+#include <gst/video/video.h>
 
 typedef struct GstPipelineCtx {
   int pipelineId;
@@ -25,3 +26,4 @@ void gstreamer_pipeline_push(GstPipelineCtx *ctx, void *buffer, int bufferLen);
 gboolean gstreamer_pipeline_set_prop_int(GstPipelineCtx *ctx, char *binName, char *prop, gint value);
 gboolean gstreamer_pipeline_set_caps_framerate(GstPipelineCtx *ctx, const gchar* binName, gint numerator, gint denominator);
 gboolean gstreamer_pipeline_set_caps_resolution(GstPipelineCtx *ctx, const gchar* binName, gint width, gint height);
+gboolean gstreamer_pipeline_emit_video_keyframe(GstPipelineCtx *ctx);


### PR DESCRIPTION
By calling this function, we force gstreamer that next sample will be keyframe.

Checking if it really is keyframe can be done (for VP8) with:
```go
isKeyFrame := sample.Data[0]&0x07 == 0
if isKeyFrame {
    logger.Info().Msg("webrtc keyframe")
}
```

Has only been tested with VP8.