### PR TITLE
Wait for keyframe on switching streams

### DIFF
--- a/internal/config/capture.go
+++ b/internal/config/capture.go
@@ -3,7 +3,6 @@ package config
 import (
 	"os"
 
-	"github.com/pion/webrtc/v3"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -171,7 +170,7 @@ func (s *Capture) Set() {
 	// video
 	videoCodec := viper.GetString("capture.video.codec")
 	s.VideoCodec, ok = codec.ParseStr(videoCodec)
-	if !ok || s.VideoCodec.Type != webrtc.RTPCodecTypeVideo {
+	if !ok || !s.VideoCodec.IsVideo() {
 		log.Warn().Str("codec", videoCodec).Msgf("unknown video codec, using Vp8")
 		s.VideoCodec = codec.VP8()
 	}
@@ -217,7 +216,7 @@ func (s *Capture) Set() {
 
 	audioCodec := viper.GetString("capture.audio.codec")
 	s.AudioCodec, ok = codec.ParseStr(audioCodec)
-	if !ok || s.AudioCodec.Type != webrtc.RTPCodecTypeAudio {
+	if !ok || !s.AudioCodec.IsAudio() {
 		log.Warn().Str("codec", audioCodec).Msgf("unknown audio codec, using Opus")
 		s.AudioCodec = codec.Opus()
 	}

--- a/internal/webrtc/track.go
+++ b/internal/webrtc/track.go
@@ -64,7 +64,10 @@ func NewTrack(logger zerolog.Logger, codec codec.RTPCodec, connection *webrtc.Pe
 			return
 		}
 
-		err := track.WriteSample(media.Sample(sample))
+		err := track.WriteSample(media.Sample{
+			Data:     sample.Data,
+			Duration: sample.Duration,
+		})
 		if err != nil && !errors.Is(err, io.ErrClosedPipe) {
 			logger.Warn().Err(err).Msg("failed to write sample to track")
 		}

--- a/pkg/gst/gst.c
+++ b/pkg/gst/gst.c
@@ -97,7 +97,7 @@ static GstFlowReturn gstreamer_send_new_sample_handler(GstElement *object, gpoin
       gst_buffer_extract_dup(buffer, 0, gst_buffer_get_size(buffer), &copy, &copy_size);
       goHandlePipelineBuffer(ctx->pipelineId, copy, copy_size,
         GST_BUFFER_DURATION(buffer),
-        !GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DELTA_UNIT)
+        GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DELTA_UNIT)
       );
     }
     gst_sample_unref(sample);

--- a/pkg/gst/gst.c
+++ b/pkg/gst/gst.c
@@ -6,7 +6,7 @@ static void gstreamer_pipeline_log(GstPipelineCtx *ctx, char* level, const char*
   char buffer[100];
   vsprintf(buffer, format, argptr);
   va_end(argptr);
-  goPipelineLog(level, buffer, ctx->pipelineId);
+  goPipelineLog(ctx->pipelineId, level, buffer);
 }
 
 static gboolean gstreamer_bus_call(GstBus *bus, GstMessage *msg, gpointer user_data) {
@@ -95,7 +95,10 @@ static GstFlowReturn gstreamer_send_new_sample_handler(GstElement *object, gpoin
     buffer = gst_sample_get_buffer(sample);
     if (buffer) {
       gst_buffer_extract_dup(buffer, 0, gst_buffer_get_size(buffer), &copy, &copy_size);
-      goHandlePipelineBuffer(copy, copy_size, GST_BUFFER_DURATION(buffer), ctx->pipelineId);
+      goHandlePipelineBuffer(ctx->pipelineId, copy, copy_size,
+        GST_BUFFER_DURATION(buffer),
+        !GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DELTA_UNIT)
+      );
     }
     gst_sample_unref(sample);
   }

--- a/pkg/gst/gst.go
+++ b/pkg/gst/gst.go
@@ -200,7 +200,7 @@ func CheckPlugins(plugins []string) error {
 }
 
 //export goHandlePipelineBuffer
-func goHandlePipelineBuffer(pipelineID C.int, buf unsafe.Pointer, bufLen C.int, duration C.guint64, isDeltaUnit C.gboolean) {
+func goHandlePipelineBuffer(pipelineID C.int, buf unsafe.Pointer, bufLen C.int, duration C.guint64, deltaUnit C.gboolean) {
 	defer C.free(buf)
 
 	pipelinesLock.Lock()
@@ -209,9 +209,9 @@ func goHandlePipelineBuffer(pipelineID C.int, buf unsafe.Pointer, bufLen C.int, 
 
 	if ok {
 		pipeline.sample <- types.Sample{
-			Data:        C.GoBytes(buf, bufLen),
-			Duration:    time.Duration(duration),
-			IsDeltaUnit: isDeltaUnit == C.TRUE,
+			Data:      C.GoBytes(buf, bufLen),
+			Duration:  time.Duration(duration),
+			DeltaUnit: deltaUnit == C.TRUE,
 		}
 	} else {
 		log.Warn().

--- a/pkg/gst/gst.go
+++ b/pkg/gst/gst.go
@@ -200,8 +200,8 @@ func CheckPlugins(plugins []string) error {
 }
 
 //export goHandlePipelineBuffer
-func goHandlePipelineBuffer(buffer unsafe.Pointer, bufferLen C.int, duration C.int, pipelineID C.int) {
-	defer C.free(buffer)
+func goHandlePipelineBuffer(pipelineID C.int, buf unsafe.Pointer, bufLen C.int, duration C.guint64, isDeltaUnit C.gboolean) {
+	defer C.free(buf)
 
 	pipelinesLock.Lock()
 	pipeline, ok := pipelines[int(pipelineID)]
@@ -209,8 +209,9 @@ func goHandlePipelineBuffer(buffer unsafe.Pointer, bufferLen C.int, duration C.i
 
 	if ok {
 		pipeline.sample <- types.Sample{
-			Data:     C.GoBytes(buffer, bufferLen),
-			Duration: time.Duration(duration),
+			Data:        C.GoBytes(buf, bufLen),
+			Duration:    time.Duration(duration),
+			IsDeltaUnit: isDeltaUnit == C.TRUE,
 		}
 	} else {
 		log.Warn().
@@ -222,7 +223,7 @@ func goHandlePipelineBuffer(buffer unsafe.Pointer, bufferLen C.int, duration C.i
 }
 
 //export goPipelineLog
-func goPipelineLog(levelUnsafe *C.char, msgUnsafe *C.char, pipelineID C.int) {
+func goPipelineLog(pipelineID C.int, levelUnsafe *C.char, msgUnsafe *C.char) {
 	levelStr := C.GoString(levelUnsafe)
 	msg := C.GoString(msgUnsafe)
 

--- a/pkg/gst/gst.h
+++ b/pkg/gst/gst.h
@@ -12,7 +12,7 @@ typedef struct GstPipelineCtx {
   GstElement *appsrc;
 } GstPipelineCtx;
 
-extern void goHandlePipelineBuffer(int pipelineId, void *buffer, int bufferLen, guint64 duration, gboolean isDeltaUnit);
+extern void goHandlePipelineBuffer(int pipelineId, void *buffer, int bufferLen, guint64 duration, gboolean deltaUnit);
 extern void goPipelineLog(int pipelineId, char *level, char *msg);
 
 GstPipelineCtx *gstreamer_pipeline_create(char *pipelineStr, int pipelineId, GError **error);

--- a/pkg/gst/gst.h
+++ b/pkg/gst/gst.h
@@ -12,8 +12,8 @@ typedef struct GstPipelineCtx {
   GstElement *appsrc;
 } GstPipelineCtx;
 
-extern void goHandlePipelineBuffer(void *buffer, int bufferLen, int samples, int pipelineId);
-extern void goPipelineLog(char *level, char *msg, int pipelineId);
+extern void goHandlePipelineBuffer(int pipelineId, void *buffer, int bufferLen, guint64 duration, gboolean isDeltaUnit);
+extern void goPipelineLog(int pipelineId, char *level, char *msg);
 
 GstPipelineCtx *gstreamer_pipeline_create(char *pipelineStr, int pipelineId, GError **error);
 void gstreamer_pipeline_attach_appsink(GstPipelineCtx *ctx, char *sinkName);

--- a/pkg/types/capture.go
+++ b/pkg/types/capture.go
@@ -6,17 +6,22 @@ import (
 	"fmt"
 	"math"
 	"strings"
+	"time"
 
 	"github.com/PaesslerAG/gval"
 	"github.com/demodesk/neko/pkg/types/codec"
-	"github.com/pion/webrtc/v3/pkg/media"
 )
 
 var (
 	ErrCapturePipelineAlreadyExists = errors.New("capture pipeline already exists")
 )
 
-type Sample media.Sample
+type Sample struct {
+	Data     []byte
+	Duration time.Duration
+	// for video this is usualy keyframe
+	IsDeltaUnit bool
+}
 
 type Receiver interface {
 	SetStream(stream StreamSinkManager) (changed bool, err error)

--- a/pkg/types/capture.go
+++ b/pkg/types/capture.go
@@ -17,10 +17,9 @@ var (
 )
 
 type Sample struct {
-	Data     []byte
-	Duration time.Duration
-	// for video this is usualy keyframe
-	IsDeltaUnit bool
+	Data      []byte
+	Duration  time.Duration
+	DeltaUnit bool // this unit cannot be decoded independently.
 }
 
 type Receiver interface {

--- a/pkg/types/codec/codecs.go
+++ b/pkg/types/codec/codecs.go
@@ -63,6 +63,18 @@ func (codec *RTPCodec) Register(engine *webrtc.MediaEngine) error {
 	}, codec.Type)
 }
 
+func (codec *RTPCodec) IsVideo() bool {
+	return codec.Type == webrtc.RTPCodecTypeVideo
+}
+
+func (codec *RTPCodec) IsAudio() bool {
+	return codec.Type == webrtc.RTPCodecTypeAudio
+}
+
+func (codec *RTPCodec) String() string {
+	return codec.Type.String() + "/" + codec.Name
+}
+
 func VP8() RTPCodec {
 	return RTPCodec{
 		Name:        "vp8",


### PR DESCRIPTION
Adding keyframe lobby to stream sink, meaning that when we switch between streams, listener goes first to a keyframe lobby, a keyframe will be requested from gstreamer pipeline, and once it arrives it will be sent to the listener.

Gstreamer tells us by identifying `delta_unit` for each sample. If sample is delta unit, it means it cannot be decoded independently. If it is not delta unit, that means we have keyframe.

This reduces unwanted artifacts and allows fast joining to a new pipeline.