### PR TITLE
GCC No-Op Pacer

### DIFF
--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -213,9 +213,13 @@ func (manager *WebRTCManagerCtx) newPeerConnection(bitrate int, codecs []codec.R
 
 	congestionController, err := cc.NewInterceptor(func() (cc.BandwidthEstimator, error) {
 		if bitrate == 0 {
-			bitrate = 1000000
+			bitrate = 1_000_000
 		}
-		return gcc.NewSendSideBWE(gcc.SendSideBWEInitialBitrate(bitrate))
+
+		return gcc.NewSendSideBWE(
+			gcc.SendSideBWEInitialBitrate(bitrate),
+			gcc.SendSideBWEPacer(gcc.NewNoOpPacer()),
+		)
 	})
 	if err != nil {
 		return nil, nil, err

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -625,12 +625,14 @@ func (manager *WebRTCManagerCtx) CreatePeer(session types.Session, bitrate int, 
 			})
 	})
 
-	videoTrack.OnRTCP(func(p rtcp.Packet) {
-		if rtcpPacket, ok := p.(*rtcp.ReceiverReport); ok {
-			l := len(rtcpPacket.Reports)
-			if l > 0 {
-				// use only last report
-				manager.metrics.SetReceiverReport(session, rtcpPacket.Reports[l-1])
+	videoTrack.OnRTCP(func(packets []rtcp.Packet) {
+		for _, p := range packets {
+			if rtcpPacket, ok := p.(*rtcp.ReceiverReport); ok {
+				l := len(rtcpPacket.Reports)
+				if l > 0 {
+					// use only last report
+					manager.metrics.SetReceiverReport(session, rtcpPacket.Reports[l-1])
+				}
 			}
 		}
 	})

--- a/internal/webrtc/track.go
+++ b/internal/webrtc/track.go
@@ -26,7 +26,7 @@ type Track struct {
 	stream   types.StreamSinkManager
 	streamMu sync.Mutex
 
-	onRtcp   func(rtcp.Packet)
+	onRtcp   func([]rtcp.Packet)
 	onRtcpMu sync.RWMutex
 
 	bitrateChange func(int) (bool, error)
@@ -81,9 +81,8 @@ func NewTrack(logger zerolog.Logger, codec codec.RTPCodec, connection *webrtc.Pe
 }
 
 func (t *Track) rtcpReader(sender *webrtc.RTPSender) {
-	rtcpBuf := make([]byte, 1500)
 	for {
-		n, _, err := sender.Read(rtcpBuf)
+		packets, _, err := sender.ReadRTCP()
 		if err != nil {
 			if err == io.EOF || err == io.ErrClosedPipe {
 				return
@@ -93,21 +92,11 @@ func (t *Track) rtcpReader(sender *webrtc.RTPSender) {
 			continue
 		}
 
-		packets, err := rtcp.Unmarshal(rtcpBuf[:n])
-		if err != nil {
-			t.logger.Err(err).Msg("RTCP unmarshal error")
-			continue
-		}
-
 		t.onRtcpMu.RLock()
-		handler := t.onRtcp
-		t.onRtcpMu.RUnlock()
-
-		for _, packet := range packets {
-			if handler != nil {
-				go handler(packet)
-			}
+		if t.onRtcp != nil {
+			go t.onRtcp(packets)
 		}
+		t.onRtcpMu.RUnlock()
 	}
 }
 
@@ -149,7 +138,7 @@ func (t *Track) SetPaused(paused bool) {
 	t.paused = paused
 }
 
-func (t *Track) OnRTCP(f func(rtcp.Packet)) {
+func (t *Track) OnRTCP(f func([]rtcp.Packet)) {
 	t.onRtcpMu.Lock()
 	defer t.onRtcpMu.Unlock()
 


### PR DESCRIPTION
https://chromium.googlesource.com/external/webrtc/+/master/modules/pacing/g3doc/index.md

> The paced sender solves this by having a buffer in which media is queued, and then using a leaky bucket algorithm to pace them onto the network.

This has been implemented with the new GCC estimator. It is not suitable for ultra real time usecases, because it creates insane delays.

Additionaly, number of RTCP reports increased after configuring TWCC header extension sender, so optimizaition has been done.