### PR TITLE
Switch to listeners for webrtc pause

### DIFF
--- a/internal/webrtc/track.go
+++ b/internal/webrtc/track.go
@@ -16,13 +16,14 @@ import (
 )
 
 type Track struct {
-	logger      zerolog.Logger
-	track       *webrtc.TrackLocalStaticSample
-	paused      bool
+	logger   zerolog.Logger
+	track    *webrtc.TrackLocalStaticSample
+	listener func(sample types.Sample)
+
 	videoAuto   bool
 	videoAutoMu sync.RWMutex
-	listener    func(sample types.Sample)
 
+	paused   bool
 	stream   types.StreamSinkManager
 	streamMu sync.Mutex
 

--- a/internal/webrtc/track.go
+++ b/internal/webrtc/track.go
@@ -109,6 +109,12 @@ func (t *Track) SetStream(stream types.StreamSinkManager) (bool, error) {
 		return false, nil
 	}
 
+	// if paused, we switch the stream but don't add the listener
+	if t.paused {
+		t.stream = stream
+		return true, nil
+	}
+
 	var err error
 	if t.stream != nil {
 		err = t.stream.MoveListenerTo(&t.listener, stream)
@@ -120,7 +126,6 @@ func (t *Track) SetStream(stream types.StreamSinkManager) (bool, error) {
 	}
 
 	t.stream = stream
-
 	return true, nil
 }
 
@@ -128,8 +133,8 @@ func (t *Track) RemoveStream() {
 	t.streamMu.Lock()
 	defer t.streamMu.Unlock()
 
-	// if there is no stream, do nothing
-	if t.stream == nil {
+	// if there is no stream, or paused, do nothing
+	if t.stream == nil || t.paused {
 		return
 	}
 


### PR DESCRIPTION
Before we only short-circuited emitting samples to the user, instead of unsubscribing the pipeline. But since we implemented keyframe lobby for streamsink, we want to use it as well here and switch only on keyframe to avoid showing artifacts.

Reimplmeneting this code has been considered as unnecessary, therefore this concept was switched to subscribing & unsubscribing each pipeline on pause events. We also needed to ensure, keyframe request won't be spamming pipeline. Therefore only first keyframe request is forwarded to the pipeline until we recive keyframe.