### PR TITLE
Passive bandwidth estimator option

### DIFF
--- a/internal/config/webrtc.go
+++ b/internal/config/webrtc.go
@@ -28,6 +28,7 @@ type WebRTC struct {
 	IpRetrievalUrl string
 
 	EstimatorEnabled        bool
+	EstimatorPassive        bool
 	EstimatorInitialBitrate int
 }
 
@@ -76,6 +77,11 @@ func (WebRTC) Init(cmd *cobra.Command) error {
 
 	cmd.PersistentFlags().Bool("webrtc.estimator.enabled", false, "enables the bandwidth estimator")
 	if err := viper.BindPFlag("webrtc.estimator.enabled", cmd.PersistentFlags().Lookup("webrtc.estimator.enabled")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Bool("webrtc.estimator.passive", false, "passive estimator mode, when it does not switch pipelines, only estimates")
+	if err := viper.BindPFlag("webrtc.estimator.passive", cmd.PersistentFlags().Lookup("webrtc.estimator.passive")); err != nil {
 		return err
 	}
 
@@ -154,5 +160,6 @@ func (s *WebRTC) Set() {
 	// bandwidth estimator
 
 	s.EstimatorEnabled = viper.GetBool("webrtc.estimator.enabled")
+	s.EstimatorPassive = viper.GetBool("webrtc.estimator.passive")
 	s.EstimatorInitialBitrate = viper.GetInt("webrtc.estimator.initial_bitrate")
 }

--- a/internal/webrtc/metrics.go
+++ b/internal/webrtc/metrics.go
@@ -27,6 +27,7 @@ type metrics struct {
 	videoIdsMu *sync.Mutex
 
 	receiverEstimatedMaximumBitrate prometheus.Gauge
+	receiverEstimatedTargetBitrate  prometheus.Gauge
 
 	receiverReportDelay     prometheus.Gauge
 	receiverReportJitter    prometheus.Gauge
@@ -140,6 +141,15 @@ func (m *metricsCtx) getBySession(session types.Session) metrics {
 			Namespace: "neko",
 			Subsystem: "webrtc",
 			Help:      "Receiver Estimated Maximum Bitrate from SCTP.",
+			ConstLabels: map[string]string{
+				"session_id": session.ID(),
+			},
+		}),
+		receiverEstimatedTargetBitrate: promauto.NewGauge(prometheus.GaugeOpts{
+			Name:      "receiver_estimated_target_bitrate",
+			Namespace: "neko",
+			Subsystem: "webrtc",
+			Help:      "Receiver Estimated Target Bitrate using Google's congestion control.",
 			ConstLabels: map[string]string{
 				"session_id": session.ID(),
 			},
@@ -327,10 +337,16 @@ func (m *metricsCtx) SetVideoID(session types.Session, videoId string) {
 	}
 }
 
-func (m *metricsCtx) SetReceiverEstimatedMaximumBitrate(session types.Session, bitrate float64) {
+func (m *metricsCtx) SetReceiverEstimatedMaximumBitrate(session types.Session, bitrate float32) {
 	met := m.getBySession(session)
 
-	met.receiverEstimatedMaximumBitrate.Set(bitrate)
+	met.receiverEstimatedMaximumBitrate.Set(float64(bitrate))
+}
+
+func (m *metricsCtx) SetReceiverEstimatedTargetBitrate(session types.Session, bitrate float64) {
+	met := m.getBySession(session)
+
+	met.receiverEstimatedTargetBitrate.Set(bitrate)
 }
 
 func (m *metricsCtx) SetReceiverReport(session types.Session, report rtcp.ReceptionReport) {

--- a/pkg/types/codec/codecs.go
+++ b/pkg/types/codec/codecs.go
@@ -8,7 +8,7 @@ import (
 
 var RTCPFeedback = []webrtc.RTCPFeedback{
 	{Type: webrtc.TypeRTCPFBTransportCC, Parameter: ""},
-	{Type: webrtc.TypeRTCPFBGoogREMB, Parameter: ""},
+	{Type: webrtc.TypeRTCPFBGoogREMB, Parameter: ""}, // TODO: Deprecated.
 
 	// https://www.iana.org/assignments/sdp-parameters/sdp-parameters.xhtml#sdp-parameters-19
 	{Type: webrtc.TypeRTCPFBCCM, Parameter: "fir"},


### PR DESCRIPTION
There should be possibility to start bandwidth estimator passively, meaning it would be enabled and estimate bandwidth to metrics, but never actually changing any pipeline.