### PR TITLE
Add plugins required flag

### DIFF
--- a/internal/config/plugins.go
+++ b/internal/config/plugins.go
@@ -6,8 +6,9 @@ import (
 )
 
 type Plugins struct {
-	Enabled bool
-	Dir     string
+	Enabled  bool
+	Dir      string
+	Required bool
 }
 
 func (Plugins) Init(cmd *cobra.Command) error {
@@ -21,10 +22,16 @@ func (Plugins) Init(cmd *cobra.Command) error {
 		return err
 	}
 
+	cmd.PersistentFlags().Bool("plugins.required", false, "if true, neko will exit if there is an error when loading a plugin")
+	if err := viper.BindPFlag("plugins.required", cmd.PersistentFlags().Lookup("plugins.required")); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (s *Plugins) Set() {
 	s.Enabled = viper.GetBool("plugins.enabled")
 	s.Dir = viper.GetString("plugins.dir")
+	s.Required = viper.GetBool("plugins.required")
 }

--- a/internal/plugins/dependency.go
+++ b/internal/plugins/dependency.go
@@ -121,10 +121,10 @@ func (a *dependency) start(pm types.PluginManagers) error {
 	}
 
 	err := a.plugin.Start(pm)
-	a.logger.Err(err).Str("plugin", a.plugin.Name()).Msg("plugin start")
 	if err != nil {
 		return fmt.Errorf("plugin %s failed to start: %s", a.plugin.Name(), err)
 	}
 
+	a.logger.Info().Str("plugin", a.plugin.Name()).Msg("plugin started")
 	return nil
 }


### PR DESCRIPTION
If true, neko will exit if there is an error when loading a plugin. This is useful for catching errors with plugins, such as:

```
plugin.Open(\"/etc/neko/plugins/myplugin\"): plugin was built with a different version of package <package>
```

Normally, this error would be only written in logs and neko would continue without the plugin. We sometimes want neko to exit.