### PR TITLE
Set max payload log size for WebSockets

### DIFF
--- a/internal/websocket/manager.go
+++ b/internal/websocket/manager.go
@@ -23,6 +23,9 @@ const pingPeriod = 10 * time.Second
 // period for sending inactive cursor messages
 const inactiveCursorsPeriod = 750 * time.Millisecond
 
+// maximum payload length for logging
+const maxPayloadLogLength = 10_000
+
 // events that are not logged in debug mode
 var nologEvents = []string{
 	// don't log twice
@@ -313,10 +316,15 @@ func (manager *WebSocketManagerCtx) handle(connection *websocket.Conn, peer type
 
 			// log events if not ignored
 			if ok, _ := utils.ArrayIn(data.Event, nologEvents); !ok {
+				payload := data.Payload
+				if len(payload) > maxPayloadLogLength {
+					payload = []byte("<truncated>")
+				}
+
 				logger.Debug().
 					Str("address", connection.RemoteAddr().String()).
 					Str("event", data.Event).
-					Str("payload", string(data.Payload)).
+					Str("payload", string(payload)).
 					Msg("received message from client")
 			}
 

--- a/internal/websocket/peer.go
+++ b/internal/websocket/peer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/demodesk/neko/pkg/types"
 	"github.com/demodesk/neko/pkg/types/event"
 	"github.com/demodesk/neko/pkg/types/message"
+	"github.com/demodesk/neko/pkg/utils"
 )
 
 type WebSocketPeerCtx struct {
@@ -60,11 +61,18 @@ func (peer *WebSocketPeerCtx) Send(event string, payload any) {
 		return
 	}
 
-	peer.logger.Debug().
-		Str("address", peer.connection.RemoteAddr().String()).
-		Str("event", event).
-		Str("payload", string(raw)).
-		Msg("sending message to client")
+	// log events if not ignored
+	if ok, _ := utils.ArrayIn(event, nologEvents); !ok {
+		if len(raw) > maxPayloadLogLength {
+			raw = []byte("<truncated>")
+		}
+
+		peer.logger.Debug().
+			Str("address", peer.connection.RemoteAddr().String()).
+			Str("event", event).
+			Str("payload", string(raw)).
+			Msg("sending message to client")
+	}
 }
 
 func (peer *WebSocketPeerCtx) Ping() error {


### PR DESCRIPTION
Docker log line can be up to 16k long, so we want to limit very long payloads for websockets.