### PR TITLE
WebRTC refactor, pt.1

### DIFF
--- a/internal/webrtc/cursor/image.go
+++ b/internal/webrtc/cursor/image.go
@@ -110,8 +110,8 @@ func (manager *image) getCached(serial uint64) (*imageEntry, error) {
 
 	if entry.Serial != serial {
 		manager.logger.Warn().
-			Uint64("requested_serial", serial).
-			Uint64("received_serial", entry.Serial).
+			Uint64("expected-serial", serial).
+			Uint64("received-serial", entry.Serial).
 			Msg("serial mismatch")
 	}
 

--- a/internal/webrtc/handler.go
+++ b/internal/webrtc/handler.go
@@ -9,11 +9,15 @@ import (
 	"github.com/demodesk/neko/internal/webrtc/payload"
 	"github.com/demodesk/neko/pkg/types"
 	"github.com/pion/webrtc/v3"
+	"github.com/rs/zerolog"
 )
 
-func (manager *WebRTCManagerCtx) handle(data []byte, dataChannel *webrtc.DataChannel, session types.Session) error {
-	// add session id to logger context
-	logger := manager.logger.With().Str("session_id", session.ID()).Logger()
+func (manager *WebRTCManagerCtx) handle(
+	logger zerolog.Logger, data []byte,
+	dataChannel *webrtc.DataChannel,
+	session types.Session,
+) error {
+	isHost := session.IsHost()
 
 	//
 	// parse header
@@ -38,7 +42,7 @@ func (manager *WebRTCManagerCtx) handle(data []byte, dataChannel *webrtc.DataCha
 		}
 
 		x, y := int(payload.X), int(payload.Y)
-		if session.IsHost() {
+		if isHost {
 			// handle active cursor movement
 			manager.desktop.Move(x, y)
 			manager.curPosition.Set(x, y)
@@ -87,7 +91,7 @@ func (manager *WebRTCManagerCtx) handle(data []byte, dataChannel *webrtc.DataCha
 	}
 
 	// continue only if session is host
-	if !session.IsHost() {
+	if !isHost {
 		return nil
 	}
 

--- a/internal/webrtc/handler.go
+++ b/internal/webrtc/handler.go
@@ -21,21 +21,14 @@ func (manager *WebRTCManagerCtx) handle(data []byte, dataChannel *webrtc.DataCha
 
 	buffer := bytes.NewBuffer(data)
 
-	hbytes := make([]byte, 3)
-	if _, err := buffer.Read(hbytes); err != nil {
-		return err
-	}
-
 	header := &payload.Header{}
-	if err := binary.Read(bytes.NewBuffer(hbytes), binary.BigEndian, header); err != nil {
+	if err := binary.Read(buffer, binary.BigEndian, header); err != nil {
 		return err
 	}
 
 	//
 	// parse body
 	//
-
-	buffer = bytes.NewBuffer(data)
 
 	// handle cursor move event
 	if header.Event == payload.OP_MOVE {
@@ -64,8 +57,8 @@ func (manager *WebRTCManagerCtx) handle(data []byte, dataChannel *webrtc.DataCha
 			return err
 		}
 
-		// change header event to pong
-		ping.Header = payload.Header{
+		// create pong header
+		header := payload.Header{
 			Event:  payload.OP_PONG,
 			Length: 19,
 		}
@@ -81,6 +74,11 @@ func (manager *WebRTCManagerCtx) handle(data []byte, dataChannel *webrtc.DataCha
 		}
 
 		buffer := &bytes.Buffer{}
+
+		if err := binary.Write(buffer, binary.BigEndian, header); err != nil {
+			return err
+		}
+
 		if err := binary.Write(buffer, binary.BigEndian, pong); err != nil {
 			return err
 		}

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -448,18 +448,23 @@ func (manager *WebRTCManagerCtx) CreatePeer(session types.Session, bitrate int, 
 	}
 
 	peer := &WebRTCPeerCtx{
-		logger:                 logger,
-		connection:             connection,
-		dataChannel:            dataChannel,
+		logger:     logger,
+		connection: connection,
+		// tracks & channels
+		audioTrack:  audioTrack,
+		videoTrack:  videoTrack,
+		dataChannel: dataChannel,
+		rtcpChannel: videoRtcp,
+		// config
+		iceTrickle: manager.config.ICETrickle,
+		// deprecated functions
 		changeVideoFromBitrate: changeVideoFromBitrate,
 		changeVideoFromID:      changeVideoFromID,
-		// TODO: Refactor.
-		videoId: videoTrack.stream.ID,
+		videoId:                videoTrack.stream.ID,
 		setPaused: func(isPaused bool) {
 			videoTrack.SetPaused(isPaused)
 			audioTrack.SetPaused(isPaused)
 		},
-		iceTrickle: manager.config.ICETrickle,
 		setVideoAuto: func(videoAuto bool) {
 			// if estimator is enabled and not in passive mode, enable video auto bitrate
 			if manager.config.EstimatorEnabled && !manager.config.EstimatorPassive {

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -562,7 +562,7 @@ func (manager *WebRTCManagerCtx) CreatePeer(session types.Session, bitrate int, 
 	})
 
 	dataChannel.OnMessage(func(message webrtc.DataChannelMessage) {
-		if err := manager.handle(message.Data, dataChannel, session); err != nil {
+		if err := manager.handle(logger, message.Data, dataChannel, session); err != nil {
 			logger.Err(err).Msg("data handle failed")
 		}
 	})

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -452,6 +452,8 @@ func (manager *WebRTCManagerCtx) CreatePeer(session types.Session, bitrate int, 
 
 	peer := &WebRTCPeerCtx{
 		logger:     logger,
+		session:    session,
+		metrics:    metrics,
 		connection: connection,
 		// tracks & channels
 		audioTrack:  audioTrack,

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -487,7 +487,7 @@ func (manager *WebRTCManagerCtx) CreatePeer(session types.Session, bitrate int, 
 			session.SetWebRTCConnected(peer, true)
 		case webrtc.PeerConnectionStateDisconnected,
 			webrtc.PeerConnectionStateFailed:
-			connection.Close()
+			peer.Destroy()
 		case webrtc.PeerConnectionStateClosed:
 			// ensure we only run this once
 			once.Do(func() {

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -360,22 +360,6 @@ func (manager *WebRTCManagerCtx) CreatePeer(session types.Session, bitrate int, 
 		rtcpChannel: videoRtcp,
 		// config
 		iceTrickle: manager.config.ICETrickle,
-		// deprecated functions
-		videoId: videoTrack.stream.ID,
-		setPaused: func(isPaused bool) {
-			videoTrack.SetPaused(isPaused)
-			audioTrack.SetPaused(isPaused)
-		},
-		setVideoAuto: func(videoAuto bool) {
-			// if estimator is enabled and not in passive mode, enable video auto bitrate
-			if manager.config.EstimatorEnabled && !manager.config.EstimatorPassive {
-				videoTrack.SetVideoAuto(videoAuto)
-			} else {
-				logger.Warn().Msg("estimator is disabled or in passive mode, cannot change video auto")
-				videoTrack.SetVideoAuto(false) // ensure video auto is disabled
-			}
-		},
-		getVideoAuto: videoTrack.VideoAuto,
 	}
 
 	manager.logger.Info().

--- a/internal/webrtc/manager.go
+++ b/internal/webrtc/manager.go
@@ -44,9 +44,6 @@ const (
 
 	// send a PLI on an interval so that the publisher is pushing a keyframe every rtcpPLIInterval
 	rtcpPLIInterval = 3 * time.Second
-
-	// how often we check the bitrate of each client. Default is 250ms
-	bitrateCheckInterval = 250 * time.Millisecond
 )
 
 func New(desktop types.DesktopManager, capture types.CaptureManager, config *config.WebRTC) *WebRTCManagerCtx {

--- a/internal/webrtc/metrics.go
+++ b/internal/webrtc/metrics.go
@@ -11,7 +11,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var connectionStatsInterval = 5 * time.Second
+const (
+	// how often to read and process webrtc connection stats
+	connectionStatsInterval = 5 * time.Second
+)
 
 type metricsManager struct {
 	mu sync.Mutex

--- a/internal/webrtc/metrics.go
+++ b/internal/webrtc/metrics.go
@@ -13,16 +13,16 @@ import (
 type metricsManager struct {
 	mu sync.Mutex
 
-	sessions map[string]metrics
+	sessions map[string]*metrics
 }
 
 func newMetricsManager() *metricsManager {
 	return &metricsManager{
-		sessions: map[string]metrics{},
+		sessions: map[string]*metrics{},
 	}
 }
 
-func (m *metricsManager) getBySession(session types.Session) metrics {
+func (m *metricsManager) getBySession(session types.Session) *metrics {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -33,7 +33,7 @@ func (m *metricsManager) getBySession(session types.Session) metrics {
 		return met
 	}
 
-	met = metrics{
+	met = &metrics{
 		sessionId: sessionId,
 
 		connectionState: promauto.NewGauge(prometheus.GaugeOpts{

--- a/internal/webrtc/payload/receive.go
+++ b/internal/webrtc/payload/receive.go
@@ -13,28 +13,20 @@ const (
 )
 
 type Move struct {
-	Header
-
 	X uint16
 	Y uint16
 }
 
 type Scroll struct {
-	Header
-
 	X int16
 	Y int16
 }
 
 type Key struct {
-	Header
-
 	Key uint32
 }
 
 type Ping struct {
-	Header
-
 	// client's timestamp split into two uint32
 	ClientTs1 uint32
 	ClientTs2 uint32

--- a/internal/webrtc/payload/send.go
+++ b/internal/webrtc/payload/send.go
@@ -9,15 +9,11 @@ const (
 )
 
 type CursorPosition struct {
-	Header
-
 	X uint16
 	Y uint16
 }
 
 type CursorImage struct {
-	Header
-
 	Width  uint16
 	Height uint16
 	Xhot   uint16

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -202,16 +202,22 @@ func (peer *WebRTCPeerCtx) SendCursorPosition(x, y int) error {
 	peer.mu.Lock()
 	defer peer.mu.Unlock()
 
+	header := payload.Header{
+		Event:  payload.OP_CURSOR_POSITION,
+		Length: 7,
+	}
+
 	data := payload.CursorPosition{
-		Header: payload.Header{
-			Event:  payload.OP_CURSOR_POSITION,
-			Length: 7,
-		},
 		X: uint16(x),
 		Y: uint16(y),
 	}
 
 	buffer := &bytes.Buffer{}
+
+	if err := binary.Write(buffer, binary.BigEndian, header); err != nil {
+		return err
+	}
+
 	if err := binary.Write(buffer, binary.BigEndian, data); err != nil {
 		return err
 	}
@@ -223,11 +229,12 @@ func (peer *WebRTCPeerCtx) SendCursorImage(cur *types.CursorImage, img []byte) e
 	peer.mu.Lock()
 	defer peer.mu.Unlock()
 
+	header := payload.Header{
+		Event:  payload.OP_CURSOR_IMAGE,
+		Length: uint16(11 + len(img)),
+	}
+
 	data := payload.CursorImage{
-		Header: payload.Header{
-			Event:  payload.OP_CURSOR_IMAGE,
-			Length: uint16(11 + len(img)),
-		},
 		Width:  cur.Width,
 		Height: cur.Height,
 		Xhot:   cur.Xhot,
@@ -235,6 +242,10 @@ func (peer *WebRTCPeerCtx) SendCursorImage(cur *types.CursorImage, img []byte) e
 	}
 
 	buffer := &bytes.Buffer{}
+
+	if err := binary.Write(buffer, binary.BigEndian, header); err != nil {
+		return err
+	}
 
 	if err := binary.Write(buffer, binary.BigEndian, data); err != nil {
 		return err

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -106,11 +106,8 @@ func (peer *WebRTCPeerCtx) Destroy() {
 	peer.mu.Lock()
 	defer peer.mu.Unlock()
 
-	if peer.connection != nil {
-		err := peer.connection.Close()
-		peer.logger.Err(err).Msg("peer connection destroyed")
-		peer.connection = nil
-	}
+	err := peer.connection.Close()
+	peer.logger.Err(err).Msg("peer connection destroyed")
 }
 
 func (peer *WebRTCPeerCtx) estimatorReader() {

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -16,6 +16,8 @@ import (
 type WebRTCPeerCtx struct {
 	mu         sync.Mutex
 	logger     zerolog.Logger
+	session    types.Session
+	metrics    *metrics
 	connection *webrtc.PeerConnection
 	// tracks & channels
 	audioTrack  *Track

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -226,6 +226,11 @@ func (peer *WebRTCPeerCtx) SendCursorPosition(x, y int) error {
 	peer.mu.Lock()
 	defer peer.mu.Unlock()
 
+	// do not send cursor position to host
+	if peer.session.IsHost() {
+		return nil
+	}
+
 	header := payload.Header{
 		Event:  payload.OP_CURSOR_POSITION,
 		Length: 7,

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -17,6 +17,11 @@ import (
 	"github.com/demodesk/neko/pkg/types/message"
 )
 
+const (
+	// how often to read and process bandwidth estimation reports
+	estimatorReadInterval = 250 * time.Millisecond
+)
+
 type WebRTCPeerCtx struct {
 	mu         sync.Mutex
 	logger     zerolog.Logger
@@ -115,7 +120,7 @@ func (peer *WebRTCPeerCtx) estimatorReader() {
 	}
 
 	// use a ticker to get current client target bitrate
-	ticker := time.NewTicker(bitrateCheckInterval)
+	ticker := time.NewTicker(estimatorReadInterval)
 	defer ticker.Stop()
 
 	for range ticker.C {

--- a/internal/websocket/handler/signal.go
+++ b/internal/websocket/handler/signal.go
@@ -6,6 +6,7 @@ import (
 	"github.com/demodesk/neko/pkg/types"
 	"github.com/demodesk/neko/pkg/types/event"
 	"github.com/demodesk/neko/pkg/types/message"
+	"github.com/pion/webrtc/v3"
 )
 
 func (h *MessageHandlerCtx) signalRequest(session types.Session, payload *message.SignalVideo) error {
@@ -83,7 +84,10 @@ func (h *MessageHandlerCtx) signalOffer(session types.Session, payload *message.
 		return errors.New("webRTC peer does not exist")
 	}
 
-	err := peer.SetOffer(payload.SDP)
+	err := peer.SetRemoteDescription(webrtc.SessionDescription{
+		SDP:  payload.SDP,
+		Type: webrtc.SDPTypeOffer,
+	})
 	if err != nil {
 		return err
 	}
@@ -108,7 +112,10 @@ func (h *MessageHandlerCtx) signalAnswer(session types.Session, payload *message
 		return errors.New("webRTC peer does not exist")
 	}
 
-	return peer.SetAnswer(payload.SDP)
+	return peer.SetRemoteDescription(webrtc.SessionDescription{
+		SDP:  payload.SDP,
+		Type: webrtc.SDPTypeAnswer,
+	})
 }
 
 func (h *MessageHandlerCtx) signalCandidate(session types.Session, payload *message.SignalCandidate) error {

--- a/pkg/types/webrtc.go
+++ b/pkg/types/webrtc.go
@@ -20,9 +20,8 @@ type ICEServer struct {
 type WebRTCPeer interface {
 	CreateOffer(ICERestart bool) (*webrtc.SessionDescription, error)
 	CreateAnswer() (*webrtc.SessionDescription, error)
-	SetOffer(sdp string) error
-	SetAnswer(sdp string) error
-	SetCandidate(candidate webrtc.ICECandidateInit) error
+	SetRemoteDescription(webrtc.SessionDescription) error
+	SetCandidate(webrtc.ICECandidateInit) error
 
 	SetVideoBitrate(bitrate int) error
 	SetVideoID(videoID string) error


### PR DESCRIPTION
- Removed anonymous functions in webrtc, moved them to webrtc peer.
- Refactor metrics - with session context, with collector functions.
- Refactor cursor images & position - use interface instead of pointer to function, rw mutex for listeners.
- Cursor images - fix invalid cache serial race condition, rw mutex for cache.
- Do not include header in data messages - no need to parse them twice.
- Fixed an error, where stream would not be cleared if video was paused.
- Fixed an error, where RTCP reader goroutine for audio could leak.
- And other minor changes...