### PR TITLE
Refactor websocket session sync

### DIFF
--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -142,7 +142,7 @@ func (manager *SessionManagerCtx) Delete(id string) error {
 	manager.sessionsMu.Unlock()
 
 	if session.State().IsConnected {
-		session.GetWebSocketPeer().Destroy("session deleted")
+		session.DestroyWebSocketPeer("session deleted")
 	}
 
 	if session.State().IsWatching {

--- a/internal/websocket/peer.go
+++ b/internal/websocket/peer.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 
 	"github.com/demodesk/neko/pkg/types"
 	"github.com/demodesk/neko/pkg/types/event"
@@ -21,20 +20,11 @@ type WebSocketPeerCtx struct {
 	connection *websocket.Conn
 }
 
-func newPeer(connection *websocket.Conn) *WebSocketPeerCtx {
-	logger := log.With().
-		Str("module", "websocket").
-		Str("submodule", "peer").
-		Logger()
-
+func newPeer(logger zerolog.Logger, connection *websocket.Conn) *WebSocketPeerCtx {
 	return &WebSocketPeerCtx{
-		logger:     logger,
+		logger:     logger.With().Str("submodule", "peer").Logger(),
 		connection: connection,
 	}
-}
-
-func (peer *WebSocketPeerCtx) setSessionID(sessionId string) {
-	peer.logger = peer.logger.With().Str("session_id", sessionId).Logger()
 }
 
 func (peer *WebSocketPeerCtx) Send(event string, payload any) {

--- a/internal/websocket/peer.go
+++ b/internal/websocket/peer.go
@@ -2,7 +2,6 @@ package websocket
 
 import (
 	"encoding/json"
-	"errors"
 	"sync"
 
 	"github.com/gorilla/websocket"
@@ -30,10 +29,6 @@ func newPeer(logger zerolog.Logger, connection *websocket.Conn) *WebSocketPeerCt
 func (peer *WebSocketPeerCtx) Send(event string, payload any) {
 	peer.mu.Lock()
 	defer peer.mu.Unlock()
-
-	if peer.connection == nil {
-		return
-	}
 
 	raw, err := json.Marshal(payload)
 	if err != nil {
@@ -69,10 +64,6 @@ func (peer *WebSocketPeerCtx) Ping() error {
 	peer.mu.Lock()
 	defer peer.mu.Unlock()
 
-	if peer.connection == nil {
-		return errors.New("peer connection not found")
-	}
-
 	// application level heartbeat
 	if err := peer.connection.WriteJSON(types.WebSocketMessage{
 		Event: event.SYSTEM_HEARTBEAT,
@@ -93,9 +84,6 @@ func (peer *WebSocketPeerCtx) Destroy(reason string) {
 	peer.mu.Lock()
 	defer peer.mu.Unlock()
 
-	if peer.connection != nil {
-		err := peer.connection.Close()
-		peer.logger.Err(err).Msg("peer connection destroyed")
-		peer.connection = nil
-	}
+	err := peer.connection.Close()
+	peer.logger.Err(err).Msg("peer connection destroyed")
 }

--- a/pkg/types/session.go
+++ b/pkg/types/session.go
@@ -46,8 +46,8 @@ type Session interface {
 	SetCursor(cursor Cursor)
 
 	// websocket
-	SetWebSocketPeer(websocketPeer WebSocketPeer)
-	SetWebSocketConnected(websocketPeer WebSocketPeer, connected bool, delayed bool)
+	ConnectWebSocketPeer(websocketPeer WebSocketPeer)
+	DisconnectWebSocketPeer(websocketPeer WebSocketPeer, delayed bool)
 	GetWebSocketPeer() WebSocketPeer
 	Send(event string, payload any)
 

--- a/pkg/types/session.go
+++ b/pkg/types/session.go
@@ -48,7 +48,7 @@ type Session interface {
 	// websocket
 	ConnectWebSocketPeer(websocketPeer WebSocketPeer)
 	DisconnectWebSocketPeer(websocketPeer WebSocketPeer, delayed bool)
-	GetWebSocketPeer() WebSocketPeer
+	DestroyWebSocketPeer(reason string)
 	Send(event string, payload any)
 
 	// webrtc


### PR DESCRIPTION
Previously webrtc and websocket peers were created similarly. But websocket has been refactored in the meantime and has slightly different connection flow that webrtc. The functions should reflect that.