### PR TITLE
Error when changing resolution while fullscreen + unminimize

### DIFF
--- a/internal/config/desktop.go
+++ b/internal/config/desktop.go
@@ -12,6 +12,8 @@ import (
 type Desktop struct {
 	Display string
 
+	Unminimize bool
+
 	ScreenWidth  int
 	ScreenHeight int
 	ScreenRate   int16
@@ -23,12 +25,19 @@ func (Desktop) Init(cmd *cobra.Command) error {
 		return err
 	}
 
+	cmd.PersistentFlags().Bool("desktop.unminimize", true, "automatically unminimize window when it is minimized")
+	if err := viper.BindPFlag("desktop.unminimize", cmd.PersistentFlags().Lookup("desktop.unminimize")); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (s *Desktop) Set() {
 	// Display is provided by env variable
 	s.Display = os.Getenv("DISPLAY")
+
+	s.Unminimize = viper.GetBool("desktop.unminimize")
 
 	s.ScreenWidth = 1280
 	s.ScreenHeight = 720

--- a/internal/desktop/manager.go
+++ b/internal/desktop/manager.go
@@ -45,6 +45,7 @@ func (manager *DesktopManagerCtx) Start() {
 		Str("screen_size", fmt.Sprintf("%dx%d@%d", width, height, rate)).
 		Msgf("setting initial screen size")
 
+	xevent.Unminimize = manager.config.Unminimize
 	go xevent.EventLoop(manager.config.Display)
 
 	// In case it was opened

--- a/pkg/xevent/xevent.c
+++ b/pkg/xevent/xevent.c
@@ -16,7 +16,7 @@ static int XEventError(Display *display, XErrorEvent *event) {
 
 void XEventLoop(char *name) {
   Display *display = XOpenDisplay(name);
-  Window root = RootWindow(display, 0);
+  Window root = DefaultRootWindow(display);
 
   int xfixes_event_base, xfixes_error_base;
   if (!XFixesQueryExtension(display, &xfixes_event_base, &xfixes_error_base)) {

--- a/pkg/xevent/xevent.c
+++ b/pkg/xevent/xevent.c
@@ -83,7 +83,7 @@ void XEventLoop(char *name) {
     if (event.type == ClientMessage) {
       Window window = event.xclient.window;
 
-      // check for window manager state change
+      // check for net window manager state (fullscreen, maximized, etc)
       if (event.xclient.message_type == XInternAtom(display, "_NET_WM_STATE", 0)) {
         // see documentation in XWindowManagerStateEvent
         Atom action = event.xclient.data.l[0];
@@ -120,6 +120,15 @@ void XEventLoop(char *name) {
             }
           }
         }
+      }
+
+      // check for window manager change state (minimize, maximize, etc)
+      if (event.xclient.message_type == XInternAtom(display, "WM_CHANGE_STATE", 0)) {
+        int window_state = event.xclient.data.l[0];
+        // NormalState - The client's top-level window is viewable.
+        // IconicState - The client's top-level window is iconic (whatever that means for this window manager).
+        // WithdrawnState - Neither the client's top-level window nor its icon is visible.
+        goXEventWMChangeState(display, window, window_state);
       }
 
       continue;

--- a/pkg/xevent/xevent.go
+++ b/pkg/xevent/xevent.go
@@ -15,6 +15,7 @@ import (
 )
 
 var Emmiter events.EventEmmiter
+var Unminimize bool = false
 var file_chooser_dialog_window uint32 = 0
 
 func init() {
@@ -66,6 +67,17 @@ func goXEventUnmapNotify(window C.Window) {
 
 	file_chooser_dialog_window = 0
 	Emmiter.Emit("file-chooser-dialog-closed")
+}
+
+//export goXEventWMChangeState
+func goXEventWMChangeState(display *C.Display, window C.Window, window_state C.ulong) {
+	// if we just realized that window is minimized and we want it to be unminimized
+	if window_state != C.NormalState && Unminimize {
+		// we want to unmap and map the window to force it to redraw
+		C.XUnmapWindow(display, window)
+		C.XMapWindow(display, window)
+		C.XFlush(display)
+	}
 }
 
 //export goXEventError

--- a/pkg/xevent/xevent.go
+++ b/pkg/xevent/xevent.go
@@ -9,7 +9,6 @@ import "C"
 
 import (
 	"strings"
-	"time"
 	"unsafe"
 
 	"github.com/kataras/go-events"
@@ -51,10 +50,6 @@ func goXEventConfigureNotify(display *C.Display, window C.Window, name *C.char, 
 		return
 	}
 
-	C.XFileChooserHide(display, window)
-
-	// Because first dialog is not put properly to background
-	time.Sleep(10 * time.Millisecond)
 	C.XFileChooserHide(display, window)
 
 	if file_chooser_dialog_window == 0 {

--- a/pkg/xevent/xevent.h
+++ b/pkg/xevent/xevent.h
@@ -3,6 +3,7 @@
 #include <X11/Xutil.h>
 #include <X11/Xatom.h>
 #include <X11/Xlib.h>
+#include <X11/extensions/Xrandr.h>
 #include <X11/extensions/Xfixes.h>
 #include <stdlib.h>
 #include <string.h>
@@ -17,4 +18,5 @@ extern int goXEventActive();
 static int XEventError(Display *display, XErrorEvent *event);
 void XEventLoop(char *display);
 
+static void XWindowManagerStateEvent(Display *display, Window window, ulong action, ulong first, ulong second);
 void XFileChooserHide(Display *display, Window window);

--- a/pkg/xevent/xevent.h
+++ b/pkg/xevent/xevent.h
@@ -12,6 +12,7 @@ extern void goXEventCursorChanged(XFixesCursorNotifyEvent event);
 extern void goXEventClipboardUpdated();
 extern void goXEventConfigureNotify(Display *display, Window window, char *name, char *role);
 extern void goXEventUnmapNotify(Window window);
+extern void goXEventWMChangeState(Display *display, Window window, ulong state);
 extern void goXEventError(XErrorEvent *event, char *message);
 extern int goXEventActive();
 

--- a/pkg/xorg/xorg.c
+++ b/pkg/xorg/xorg.c
@@ -231,7 +231,7 @@ void XKey(KeySym keysym, int down) {
 
 Status XSetScreenConfiguration(int width, int height, short rate) {
   Display *display = getXDisplay();
-  Window root = RootWindow(display, 0);
+  Window root = DefaultRootWindow(display);
   XRRScreenConfiguration *conf = XRRGetScreenInfo(display, root);
 
   XRRScreenSize *xrrs;
@@ -260,7 +260,7 @@ Status XSetScreenConfiguration(int width, int height, short rate) {
 
 void XGetScreenConfiguration(int *width, int *height, short *rate) {
   Display *display = getXDisplay();
-  Window root = RootWindow(display, 0);
+  Window root = DefaultRootWindow(display);
   XRRScreenConfiguration *conf = XRRGetScreenInfo(display, root);
 
   Rotation current_rotation;
@@ -284,7 +284,7 @@ void XGetScreenConfiguration(int *width, int *height, short *rate) {
 
 void XGetScreenConfigurations() {
   Display *display = getXDisplay();
-  Window root = RootWindow(display, 0);
+  Window root = DefaultRootWindow(display);
   XRRScreenSize *xrrs;
   int num_sizes;
 
@@ -304,7 +304,7 @@ void XGetScreenConfigurations() {
 // Inspired by https://github.com/raboof/xrandr/blob/master/xrandr.c
 void XCreateScreenMode(int width, int height, short rate) {
   Display *display = getXDisplay();
-  Window root = RootWindow(display, 0);
+  Window root = DefaultRootWindow(display);
 
   char name[128];
   XRRModeInfo mode;


### PR DESCRIPTION
When going fullscreen, resizing screen and then exiting fullscreen, original window is misplaced. This issue happend for `openbox` and `metacity` window managers. `ratpoison` or not using wm at all does not  cause this issue.

According to https://specifications.freedesktop.org/wm-spec/wm-spec-1.3.html#id2731936:

> _NET_WM_STATE_FULLSCREEN indicates that the window should fill the entire screen and have no window decorations. Additionally the **Window Manager is responsible for restoring the original geometry after a switch from fullscreen back to normal window**. For example, a presentation program would use this hint.

Window Manager should be the one to restore the window properly, but it does not. Therefore we listen to `_NET_WM_STATE_FULLSCREEN` events, and when the screen was changed between joining and exitting fullscreen, we toggle maximize on that window twice, what brings it back to the desired position. 

Additionally, if you minimize window there is no way of getting it back up. Therefore we listen to minimize events and unminimize it everytime.