### PR TITLE
Add locked controls to settings

### DIFF
--- a/internal/api/room/control.go
+++ b/internal/api/room/control.go
@@ -39,6 +39,10 @@ func (h *RoomHandler) controlRequest(w http.ResponseWriter, r *http.Request) err
 	}
 
 	session, _ := auth.GetSession(r)
+	if h.sessions.Settings().LockedControls && !session.Profile().IsAdmin {
+		return utils.HttpForbidden("controls are locked")
+	}
+
 	h.sessions.SetHost(session)
 
 	return utils.HttpSuccess(w)

--- a/internal/config/session.go
+++ b/internal/config/session.go
@@ -10,6 +10,8 @@ import (
 type Session struct {
 	File string
 
+	PrivateMode       bool
+	LockedControls    bool
 	ImplicitHosting   bool
 	InactiveCursors   bool
 	MercifulReconnect bool
@@ -24,6 +26,16 @@ type Session struct {
 func (Session) Init(cmd *cobra.Command) error {
 	cmd.PersistentFlags().String("session.file", "", "if sessions should be stored in a file, otherwise they will be stored only in memory")
 	if err := viper.BindPFlag("session.file", cmd.PersistentFlags().Lookup("session.file")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Bool("session.private_mode", false, "whether private mode should be enabled initially")
+	if err := viper.BindPFlag("session.private_mode", cmd.PersistentFlags().Lookup("session.private_mode")); err != nil {
+		return err
+	}
+
+	cmd.PersistentFlags().Bool("session.locked_controls", false, "whether controls should be locked for users initially")
+	if err := viper.BindPFlag("session.locked_controls", cmd.PersistentFlags().Lookup("session.locked_controls")); err != nil {
 		return err
 	}
 
@@ -74,6 +86,8 @@ func (Session) Init(cmd *cobra.Command) error {
 func (s *Session) Set() {
 	s.File = viper.GetString("session.file")
 
+	s.PrivateMode = viper.GetBool("session.private_mode")
+	s.LockedControls = viper.GetBool("session.locked_controls")
 	s.ImplicitHosting = viper.GetBool("session.implicit_hosting")
 	s.InactiveCursors = viper.GetBool("session.inactive_cursors")
 	s.MercifulReconnect = viper.GetBool("session.merciful_reconnect")

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -20,6 +20,7 @@ func New(config *config.Session) *SessionManagerCtx {
 		config: config,
 		settings: types.Settings{
 			PrivateMode:       false, // By default disabled.
+			LockedControls:    false, // By default disabled.
 			ImplicitHosting:   config.ImplicitHosting,
 			InactiveCursors:   config.InactiveCursors,
 			MercifulReconnect: config.MercifulReconnect,
@@ -384,6 +385,15 @@ func (manager *SessionManagerCtx) UpdateSettings(new types.Settings) {
 			if webrtcPeer := session.GetWebRTCPeer(); webrtcPeer != nil {
 				webrtcPeer.SetPaused(enabled)
 			}
+		}
+	}
+
+	// if contols have been locked
+	if old.LockedControls != new.LockedControls && new.LockedControls {
+		// if the host is not admin, it must release controls
+		host, hasHost := manager.GetHost()
+		if hasHost && !host.Profile().IsAdmin {
+			manager.ClearHost()
 		}
 	}
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -19,8 +19,8 @@ func New(config *config.Session) *SessionManagerCtx {
 		logger: log.With().Str("module", "session").Logger(),
 		config: config,
 		settings: types.Settings{
-			PrivateMode:       false, // By default disabled.
-			LockedControls:    false, // By default disabled.
+			PrivateMode:       config.PrivateMode,
+			LockedControls:    config.LockedControls,
 			ImplicitHosting:   config.ImplicitHosting,
 			InactiveCursors:   config.InactiveCursors,
 			MercifulReconnect: config.MercifulReconnect,

--- a/internal/websocket/handler/control.go
+++ b/internal/websocket/handler/control.go
@@ -40,6 +40,10 @@ func (h *MessageHandlerCtx) controlRequest(session types.Session) error {
 		return ErrIsAlreadyTheHost
 	}
 
+	if h.sessions.Settings().LockedControls && !session.Profile().IsAdmin {
+		return ErrIsNotAllowedToHost
+	}
+
 	if !h.sessions.Settings().ImplicitHosting {
 		// tell session if there is a host
 		if host, hasHost := h.sessions.GetHost(); hasHost {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1024,6 +1024,8 @@ components:
       properties:
         private_mode:
           type: boolean
+        locked_controls:
+          type: boolean
         implicit_hosting:
           type: boolean
         inactive_cursors:

--- a/pkg/types/session.go
+++ b/pkg/types/session.go
@@ -30,6 +30,7 @@ type SessionState struct {
 
 type Settings struct {
 	PrivateMode       bool `json:"private_mode"`
+	LockedControls    bool `json:"locked_controls"`
 	ImplicitHosting   bool `json:"implicit_hosting"`
 	InactiveCursors   bool `json:"inactive_cursors"`
 	MercifulReconnect bool `json:"merciful_reconnect"`


### PR DESCRIPTION
So that we can toggle globally if users should have locked or unlocked controls. Only admins can modify this and it won't affect them.