### PR TITLE
Add stats for state

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -45,6 +45,7 @@ func (api *ApiManagerCtx) Route(r types.Router) {
 
 		r.Post("/logout", api.Logout)
 		r.Get("/whoami", api.Whoami)
+		r.Get("/sessions", api.Sessions)
 
 		membersHandler := members.New(api.members)
 		r.Route("/members", membersHandler.Route)

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -81,3 +81,16 @@ func (api *ApiManagerCtx) Whoami(w http.ResponseWriter, r *http.Request) error {
 		State:   session.State(),
 	})
 }
+
+func (api *ApiManagerCtx) Sessions(w http.ResponseWriter, r *http.Request) error {
+	sessions := []SessionDataPayload{}
+	for _, session := range api.sessions.List() {
+		sessions = append(sessions, SessionDataPayload{
+			ID:      session.ID(),
+			Profile: session.Profile(),
+			State:   session.State(),
+		})
+	}
+
+	return utils.HttpSuccess(w, sessions)
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -116,6 +116,25 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
+  /api/sessions:
+    get:
+      tags:
+        - session
+      summary: get sessions
+      operationId: sessionsGet
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SessionData'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   #
   # room

--- a/pkg/types/session.go
+++ b/pkg/types/session.go
@@ -3,6 +3,7 @@ package types
 import (
 	"errors"
 	"net/http"
+	"time"
 )
 
 var (
@@ -25,7 +26,16 @@ type SessionProfile struct {
 
 type SessionState struct {
 	IsConnected bool `json:"is_connected"`
-	IsWatching  bool `json:"is_watching"`
+	// when the session was last connected
+	ConnectedSince *time.Time `json:"connected_since,omitempty"`
+	// when the session was last not connected
+	NotConnectedSince *time.Time `json:"not_connected_since,omitempty"`
+
+	IsWatching bool `json:"is_watching"`
+	// when the session was last watching
+	WatchingSince *time.Time `json:"watching_since,omitempty"`
+	// when the session was last not watching
+	NotWatchingSince *time.Time `json:"not_watching_since,omitempty"`
 }
 
 type Settings struct {


### PR DESCRIPTION
Add `/api/sessions` endpoint, so that we can get information about who is currently in the room.

Add `watching_since`, `not_watching_since`, `connected_since` and `not_connected_since` to state so that we know when the state changed the last time.

This information can be used by the external system to determine:
- how many people (admins and/or users) are currently connected
- when the last person (admin and/or user) disconnected
- are the connected persons actually watching?

This is an attempt to have similar (but more granular) functionality as `last_admin_left_at` and `last_user_left_at` from m1k1o/neko's `/stats` endpoint.