### PR TITLE
Fix noisy errors

### DIFF
--- a/internal/api/room/upload.go
+++ b/internal/api/room/upload.go
@@ -95,15 +95,13 @@ func (h *RoomHandler) uploadDialogPost(w http.ResponseWriter, r *http.Request) e
 	//nolint
 	defer r.MultipartForm.RemoveAll()
 
-	if !h.desktop.IsFileChooserDialogOpened() {
-		return utils.HttpUnprocessableEntity("file chooser dialog is not open")
-	}
-
 	req_files := r.MultipartForm.File["files"]
 	if len(req_files) == 0 {
-		return utils.HttpInternalServerError().
-			WithInternalErr(err).
-			WithInternalMsg("unable to copy uploaded file to destination file")
+		return utils.HttpBadRequest("no files received")
+	}
+
+	if !h.desktop.IsFileChooserDialogOpened() {
+		return utils.HttpUnprocessableEntity("file chooser dialog is not open")
 	}
 
 	dir, err := os.MkdirTemp("", "neko-dialog-*")

--- a/internal/webrtc/peer.go
+++ b/internal/webrtc/peer.go
@@ -109,7 +109,13 @@ func (peer *WebRTCPeerCtx) Destroy() {
 	peer.mu.Lock()
 	defer peer.mu.Unlock()
 
-	err := peer.connection.Close()
+	var err error
+
+	// if peer connection is not closed, close it
+	if peer.connection.ConnectionState() != webrtc.PeerConnectionStateClosed {
+		err = peer.connection.Close()
+	}
+
 	peer.logger.Err(err).Msg("peer connection destroyed")
 }
 

--- a/internal/websocket/peer.go
+++ b/internal/websocket/peer.go
@@ -2,6 +2,7 @@ package websocket
 
 import (
 	"encoding/json"
+	"errors"
 	"sync"
 
 	"github.com/gorilla/websocket"
@@ -42,7 +43,8 @@ func (peer *WebSocketPeerCtx) Send(event string, payload any) {
 	})
 
 	if err != nil {
-		peer.logger.Err(err).Str("event", event).Msg("send message error")
+		err = errors.Unwrap(err) // unwrap if possible
+		peer.logger.Warn().Err(err).Str("event", event).Msg("send message error")
 		return
 	}
 


### PR DESCRIPTION
| error | comment |
| ----- | ------- |
| `send message error` | -> WARN |
| `request failed (502): *` | _unchanged_ |
| `request failed (500): unable to copy uploaded file to destination file` | If no files received, should be `Bad Request` -> WARN. |
| `read message error` | -> WARN |
| `peer connection destroyed` | `dtls fatal: conn is closed`: do not close webrtc if already closed |
| `mux: ending readLoop dispatch error io: read/write on closed pipe` and `Incoming unhandled RTP ssrc(*), OnTrack will not be fired. mid RTP Extensions required for Simulcast` | error from pion codebase |
| `error while processing websocket event` | _unchanged_, relevant error from client |
| `error getting candidate pairs stats the agent is closed` | error from pion codebase, seen only when shutting down server  |
| `data handle failed`, `failed to set cursor position` and `failed to set cursor image` | Right before that, TCP mux failed with `error reading streaming packet: EOF` (but log severity was `info`), sending data through datachannel did not work, it dailed with `stream closed` and shortly after webrtc connection has been closed. Is most likely an issue in pion's TCP disconnect handling. |
| `could not get clipboard content` | `Error: target STRING not available` somebody copied an image maybe, but definitely not a string. Followup could be to check what has been copied and try to get (any) data to the user, not just text. |