### PR TITLE
Move X11 error handler registration to before screen sets

### DIFF
--- a/internal/desktop/manager.go
+++ b/internal/desktop/manager.go
@@ -50,6 +50,9 @@ func (manager *DesktopManagerCtx) Start() {
 		manager.logger.Panic().Str("display", manager.config.Display).Msg("unable to open display")
 	}
 
+	// X11 can throw errors below, and the default error handler exits
+	xevent.SetupErrorHandler()
+
 	xorg.GetScreenConfigurations()
 
 	screenSize, err := xorg.ChangeScreenSize(manager.config.ScreenSize)

--- a/pkg/xevent/xevent.c
+++ b/pkg/xevent/xevent.c
@@ -14,6 +14,10 @@ static int XEventError(Display *display, XErrorEvent *event) {
   return 1;
 }
 
+void XSetupErrorHandler() {
+  XSetErrorHandler(XEventError);
+}
+
 void XEventLoop(char *name) {
   Display *display = XOpenDisplay(name);
   Window root = DefaultRootWindow(display);
@@ -33,7 +37,6 @@ void XEventLoop(char *name) {
   XSelectInput(display, root, SubstructureNotifyMask);
 
   XSync(display, 0);
-  XSetErrorHandler(XEventError);
 
   while (goXEventActive()) {
     XEvent event;

--- a/pkg/xevent/xevent.go
+++ b/pkg/xevent/xevent.go
@@ -23,6 +23,10 @@ func init() {
 	Emmiter = events.New()
 }
 
+func SetupErrorHandler() {
+	C.XSetupErrorHandler()
+}
+
 func EventLoop(display string) {
 	displayUnsafe := C.CString(display)
 	defer C.free(unsafe.Pointer(displayUnsafe))

--- a/pkg/xevent/xevent.h
+++ b/pkg/xevent/xevent.h
@@ -17,6 +17,7 @@ extern void goXEventError(XErrorEvent *event, char *message);
 extern int goXEventActive();
 
 static int XEventError(Display *display, XErrorEvent *event);
+void XSetupErrorHandler();
 void XEventLoop(char *display);
 
 static void XWindowManagerStateEvent(Display *display, Window window, ulong action, ulong first, ulong second);


### PR DESCRIPTION
If X11 throws an error during screen config get/set, the default error handler at the time will be one which causes a program exit. This splits the error handler registration in xevent into its own call, allowing us to register our error handler earlier on. This results in the safe error handling logic actually being called instead of a full program exit.